### PR TITLE
Remove venv activation from start commands

### DIFF
--- a/github_ready/DEPLOYMENT.md
+++ b/github_ready/DEPLOYMENT.md
@@ -46,6 +46,8 @@ git push origin main
 3. **Automatic Detection**
    - Railway will automatically detect your project configuration
    - It will use the `railway.json` and `Procfile` we created
+   - Both files define the start command `python backend/src/main.py` (no
+     virtualenv activation needed)
 
 4. **Wait for Build**
    - Railway will build your project (takes 2-3 minutes)

--- a/github_ready/Procfile
+++ b/github_ready/Procfile
@@ -1,2 +1,2 @@
-web: cd backend && source venv/bin/activate && python src/main.py
+web: python backend/src/main.py
 

--- a/github_ready/railway.json
+++ b/github_ready/railway.json
@@ -3,7 +3,7 @@
     "builder": "NIXPACKS"
   },
   "deploy": {
-    "startCommand": "cd backend && source venv/bin/activate && python src/main.py",
+    "startCommand": "python backend/src/main.py",
     "healthcheckPath": "/api/health",
     "healthcheckTimeout": 100,
     "restartPolicyType": "ON_FAILURE",


### PR DESCRIPTION
## Summary
- run python directly in Procfile and railway.json
- note the new start command in the deployment guide

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68417f1c1ac083229d1f685be4eca567